### PR TITLE
Fix Documentation build broken by README port

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ITensorVisualizationBase"
 uuid = "cd2553d2-8bef-4d93-8a38-c62f17d5ad23"
-version = "0.1.16"
+version = "0.1.17"
 authors = ["Matthew Fishman <mfishman@flatironinstitute.org> and contributors"]
 
 [workspace]

--- a/README.md
+++ b/README.md
@@ -49,25 +49,15 @@ or `ITensorGLMakie`. The main purpose is to use it with the
 [ITensors.jl](https://github.com/ITensor/ITensors.jl) package to view and debug tensor
 network contractions, for example:
 
+Load a visualization backend (such as `using ITensorUnicodePlots`) to actually render
+the diagrams; without one, the `@visualize` macro is a no-op so that the example below
+still runs in test environments that do not have a backend installed.
+`ITensorVisualizationBase` handles the logic of switching between backends.
+
 ````julia
 using ITensorVisualizationBase: ITensorVisualizationBase, @visualize
 using ITensors: Index, random_itensor
-````
-
-Load a visualization backend, which will reexport the interface of
-`ITensorVisualizationBase` automatically:
-```julia
-using ITensorUnicodePlots
-```
-
-(we leave the `using ITensorUnicodePlots` line out of this example so it can run in
-test environments that do not have the backend installed.)
-
-`ITensorVisualizationBase` handles the logic of switching between backends:
-
-````julia
 @show ITensorVisualizationBase.get_backend()
-
 i = Index(2, "i")
 j = Index(10, "j")
 k = Index(40, "k")
@@ -77,9 +67,10 @@ A = random_itensor(i, j, k)
 B = random_itensor(i, j, l, m)
 C = random_itensor(k, l)
 ABC = @visualize A * B * C
+ABC_tags = @visualize A * B * C edge_labels = (tags = true,)
 ````
 
-With the `ITensorUnicodePlots` backend loaded, this outputs:
+With `ITensorUnicodePlots` loaded, the first `@visualize` call outputs:
 
 ```julia
 ITensorVisualizationBase.get_backend() = ITensorVisualizationBase.Backend{:UnicodePlots}()⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
@@ -106,11 +97,7 @@ ITensorVisualizationBase.get_backend() = ITensorVisualizationBase.Backend{:Unico
     ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
 ```
 
-You can show the visualization with tags with:
-
-````julia
-ABC_tags = @visualize A * B * C edge_labels = (tags = true,)
-````
+And the second `@visualize` call (with `edge_labels = (tags = true,)`) outputs:
 
 ```julia
     ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -2,6 +2,7 @@
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 ITensorFormatter = "b6bf39f1-c9d3-4bad-aad8-593d802f65fd"
 ITensorVisualizationBase = "cd2553d2-8bef-4d93-8a38-c62f17d5ad23"
+ITensors = "9136182c-28ba-11e9-034c-db9fb085ebd5"
 
 [sources.ITensorVisualizationBase]
 path = ".."
@@ -10,3 +11,4 @@ path = ".."
 Documenter = "1"
 ITensorFormatter = "0.2.27"
 ITensorVisualizationBase = "0.1"
+ITensors = "0.7, 0.8, 0.9"

--- a/examples/README.jl
+++ b/examples/README.jl
@@ -51,24 +51,14 @@ julia> Pkg.add("ITensorVisualizationBase")
 # [ITensors.jl](https://github.com/ITensor/ITensors.jl) package to view and debug tensor
 # network contractions, for example:
 
+# Load a visualization backend (such as `using ITensorUnicodePlots`) to actually render
+# the diagrams; without one, the `@visualize` macro is a no-op so that the example below
+# still runs in test environments that do not have a backend installed.
+# `ITensorVisualizationBase` handles the logic of switching between backends.
+
 using ITensorVisualizationBase: ITensorVisualizationBase, @visualize
 using ITensors: Index, random_itensor
-
-# Load a visualization backend, which will reexport the interface of
-# `ITensorVisualizationBase` automatically:
-#=
-```julia
-using ITensorUnicodePlots
-```
-=#
-
-# (we leave the `using ITensorUnicodePlots` line out of this example so it can run in
-# test environments that do not have the backend installed.)
-
-# `ITensorVisualizationBase` handles the logic of switching between backends:
-
 @show ITensorVisualizationBase.get_backend()
-
 i = Index(2, "i")
 j = Index(10, "j")
 k = Index(40, "k")
@@ -78,8 +68,9 @@ A = random_itensor(i, j, k)
 B = random_itensor(i, j, l, m)
 C = random_itensor(k, l)
 ABC = @visualize A * B * C
+ABC_tags = @visualize A * B * C edge_labels = (tags = true,)
 
-# With the `ITensorUnicodePlots` backend loaded, this outputs:
+# With `ITensorUnicodePlots` loaded, the first `@visualize` call outputs:
 
 #=
 ```julia
@@ -108,9 +99,7 @@ ITensorVisualizationBase.get_backend() = ITensorVisualizationBase.Backend{:Unico
 ```
 =#
 
-# You can show the visualization with tags with:
-
-ABC_tags = @visualize A * B * C edge_labels = (tags = true,)
+# And the second `@visualize` call (with `edge_labels = (tags = true,)`) outputs:
 
 #=
 ```julia


### PR DESCRIPTION
## Summary

- The README port in #21 split the runnable Julia in `examples/README.jl` into two bare-Julia code blocks (imports, then setup + `@visualize` calls) separated by prose. Literate's `DocumenterFlavor` turned each into its own `@example index` block in `docs/src/index.md`. Inter-block state did not propagate on the Documentation CI runner, so `Index` was undefined when the second block ran. Independently, `docs/Project.toml` was missing `ITensors` as a dependency — so even a single-block setup couldn't have resolved `using ITensors: Index, random_itensor` during the Documenter build.
- Consolidate the runnable Julia in `examples/README.jl` into one bare-Julia block so it lands as a single `@example index` block in `index.md`. Both `@visualize` calls now sit together; the surrounding prose was rearranged so the lead-in still flows.
- Add `ITensors` to `docs/Project.toml` `[deps]` and `[compat]` (matching the root `Project.toml` compat range) so the Documenter build can resolve the import.
- Bump `Project.toml` patch version 0.1.16 → 0.1.17.

Verified locally: `docs/make.jl` now completes successfully, and `include("examples/README.jl")` from the test environment still runs the example through the no-op default backend.