### PR TITLE
Make ITensorMPS a weak dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 .benchmarkci
 .tmp
 .vscode/
+.worktrees/
 LocalPreferences.toml
 Manifest*.toml
 benchmark/*.json

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ITensorVisualizationBase"
 uuid = "cd2553d2-8bef-4d93-8a38-c62f17d5ad23"
-version = "0.1.18"
+version = "0.1.19"
 authors = ["Matthew Fishman <mfishman@flatironinstitute.org> and contributors"]
 
 [workspace]
@@ -11,13 +11,18 @@ AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 GeometryBasics = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
 Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
-ITensorMPS = "0d1a4710-d33b-49a5-8f18-73bdf49b47e2"
 ITensors = "9136182c-28ba-11e9-034c-db9fb085ebd5"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MetaGraphs = "626554b9-1ddb-594c-aa3c-2596fe9399a5"
 NetworkLayout = "46757867-2c16-5918-afeb-47bfcb05e46a"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+
+[weakdeps]
+ITensorMPS = "0d1a4710-d33b-49a5-8f18-73bdf49b47e2"
+
+[extensions]
+ITensorVisualizationBaseITensorMPSExt = "ITensorMPS"
 
 [compat]
 AbstractTrees = "0.4"

--- a/ext/ITensorVisualizationBaseITensorMPSExt.jl
+++ b/ext/ITensorVisualizationBaseITensorMPSExt.jl
@@ -1,0 +1,10 @@
+module ITensorVisualizationBaseITensorMPSExt
+
+import ITensors.ITensorVisualizationCore: visualize, visualize!
+using ITensorMPS: MPS
+using ITensors: data
+
+visualize(ψ::MPS, args...; kwargs...) = visualize(data(ψ), args...; kwargs...)
+visualize!(fig, ψ::MPS, sequence = nothing; kwargs...) = visualize!(fig, data(ψ); kwargs...)
+
+end

--- a/src/ITensorVisualizationBase.jl
+++ b/src/ITensorVisualizationBase.jl
@@ -9,7 +9,7 @@ using Graphs: Graphs, AbstractEdge, AbstractGraph, SimpleDiGraph, SimpleGraph, a
     add_vertex!, all_neighbors, dst, edges, ne, neighbors, nv, src, vertices
 using ITensors
 using ITensors.ITensorVisualizationCore
-using ITensors: QNIndex, data
+using ITensors: QNIndex
 using LinearAlgebra
 using MetaGraphs
 using NetworkLayout

--- a/src/visualize.jl
+++ b/src/visualize.jl
@@ -1,5 +1,3 @@
-using ITensorMPS: MPS
-
 #
 # Contraction sequence
 #
@@ -115,7 +113,6 @@ end
 function visualize(tn::Tuple{Vector{ITensor}}, args...; kwargs...)
     return visualize(only(tn), args...; kwargs...)
 end
-visualize(ψ::MPS, args...; kwargs...) = visualize(data(ψ), args...; kwargs...)
 function visualize(tn::Tuple{ITensor, Vararg{ITensor}}, args...; kwargs...)
     return visualize(collect(tn), args...; kwargs...)
 end
@@ -142,7 +139,6 @@ end
 function visualize!(fig, tn::Vector{ITensor}, sequence = nothing; kwargs...)
     return visualize!(fig, MetaDiGraph(tn); kwargs...)
 end
-visualize!(fig, ψ::MPS, sequence = nothing; kwargs...) = visualize!(fig, data(ψ); kwargs...)
 function visualize!(fig, tn::Tuple{Vararg{ITensor}}, sequence = nothing; kwargs...)
     return visualize!(fig, collect(tn); kwargs...)
 end


### PR DESCRIPTION
## Summary

- Move `ITensorMPS` from `[deps]` to `[weakdeps]` so users who don't need MPS-aware visualization don't pay the cost of loading `ITensorMPS`.
- Add a package extension `ITensorVisualizationBaseITensorMPSExt` (the first extension in this package) that defines the two `MPS`-specialized `visualize` / `visualize!` methods. The extension loads only when `ITensorMPS` is present.
- Bump version to 0.1.19.